### PR TITLE
Add Github action to lint when PR comment is made

### DIFF
--- a/.github/workflows/black-code-formatter.yml
+++ b/.github/workflows/black-code-formatter.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request, issue_comment ]
 
 jobs:
   lint:
-    if: !contains(github.event_name, 'issue_comment') # Don't want to trigger on comments
+    if: ${{ !contains(github.event_name, 'issue_comment') }} # Don't want to trigger on comments
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -13,7 +13,7 @@ jobs:
           options: "--check"
           src: "./ersilia"
   comment-lint:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '✨')
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '✨') }}
     runs-on: ubuntu-latest
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the

--- a/.github/workflows/black-code-formatter.yml
+++ b/.github/workflows/black-code-formatter.yml
@@ -1,6 +1,10 @@
 name: Python Black Linter
 
-on: [ push, pull_request, issue_comment ]
+on:
+  push:
+  pull_request:
+  issue_comment:
+    types: [ created, edited ]
 
 jobs:
   lint:

--- a/.github/workflows/black-code-formatter.yml
+++ b/.github/workflows/black-code-formatter.yml
@@ -1,6 +1,6 @@
 name: Python Black Linter
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   lint:
@@ -11,3 +11,19 @@ jobs:
         with:
           options: "--check"
           src: "./ersilia"
+  comment-lint:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '✨')
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+      - name: Lint files
+        uses: psf/black@stable
+        with:
+          src: "./ersilia"
+      - name: Commit lint
+        uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/black-code-formatter.yml
+++ b/.github/workflows/black-code-formatter.yml
@@ -1,9 +1,10 @@
 name: Python Black Linter
 
-on: [ push, pull_request ]
+on: [ push, pull_request, issue_comment ]
 
 jobs:
   lint:
+    if: !contains(github.event_name, 'issue_comment') # Don't want to trigger on comments
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -5,6 +5,7 @@ class RunTracker:
 
     NOTE: Currently, the Splunk connection is not set up. For now, we will print tracking results to the console.
     """
+
     def track(self, input, result, meta):
         """
         Tracks the results after a model run.

--- a/ersilia/core/tracking.py
+++ b/ersilia/core/tracking.py
@@ -5,7 +5,6 @@ class RunTracker:
 
     NOTE: Currently, the Splunk connection is not set up. For now, we will print tracking results to the console.
     """
-
     def track(self, input, result, meta):
         """
         Tracks the results after a model run.


### PR DESCRIPTION
Right now we only have a Github action that checks if files are well-formatted or not. To avoid making everyone run the linter on their computers, we can add a new Github action to lint and commit files when triggered by the PR comment "✨".